### PR TITLE
Add help message if no arguments given.

### DIFF
--- a/build.py
+++ b/build.py
@@ -90,6 +90,8 @@ def main(cmd_line_args):
                 build(mcu_switch, cmd_line_args.doxygen)
             else:
                 build(mcu_switch)
+    else:
+        print "Add argument -h or --help for instructions"
 if __name__ == '__main__':
     HELP_TEXT = """This script builds the software and documentation
 repositories based on the specified commands."""


### PR DESCRIPTION
If you run build.py with no arguments it exits without doing anything. This adds a slightly more useful message.